### PR TITLE
Added for only one recording at a time

### DIFF
--- a/rust-webserver/src/main.rs
+++ b/rust-webserver/src/main.rs
@@ -150,15 +150,16 @@ async fn main() -> std::io::Result<()> {
     let redis_url: String = env::var("REDIS_URL_GSTREAMER_PIPELINE").unwrap_or("none".to_string());
     let actor = RedisActor::new(redis_url).await;
     let addr = actor.start();
-    let is_recording = Arc::new(AtomicBool::new(false));
-    
+    println!("Random Random Random 1");
+    let is_recording_new = Arc::new(AtomicBool::new(false));
+    println!("Random Random Random 2");
     HttpServer::new(move || {
         App::new()
             .app_data( 
                 web::Data::new(RwLock::new(AppState {
                     map: HashMap::new(),
                     conn: addr.clone(),
-                    is_recording: is_recording.clone()
+                    is_recording: is_recording_new.clone()
             })).clone())
             .service(web::resource("/user/startRecording").route(web::post().to(repositories::user_repository::start_recording)))
             .service(web::resource("/user/stopRecording").route(web::post().to(repositories::user_repository::stop_recording)))

--- a/rust-webserver/src/main.rs
+++ b/rust-webserver/src/main.rs
@@ -168,4 +168,5 @@ async fn main() -> std::io::Result<()> {
     .bind(("0.0.0.0", 8080))?
     .run()
     .await
+    println!("Random Random Random 3");
 }

--- a/rust-webserver/src/main.rs
+++ b/rust-webserver/src/main.rs
@@ -20,6 +20,7 @@ use libc::{kill, SIGTERM};
 use serde_json::Error;
 use nix::unistd::Pid;
 use nix::sys::signal::{self, Signal};
+use std::sync::Arc;
 
 impl RedisActor {
     pub async fn new(redis_url: String) -> Self {
@@ -154,7 +155,8 @@ async fn main() -> std::io::Result<()> {
             .app_data( 
                 web::Data::new(RwLock::new(AppState {
                     map: HashMap::new(),
-                    conn: addr.clone()
+                    conn: addr.clone(),
+                    is_recording: Arc::new(RwLock::new(false))
             })).clone())
             .service(web::resource("/user/startRecording").route(web::post().to(repositories::user_repository::start_recording)))
             .service(web::resource("/user/stopRecording").route(web::post().to(repositories::user_repository::stop_recording)))

--- a/rust-webserver/src/main.rs
+++ b/rust-webserver/src/main.rs
@@ -151,15 +151,13 @@ async fn main() -> std::io::Result<()> {
     let actor = RedisActor::new(redis_url).await;
     let addr = actor.start();
     println!("Random Random Random 1");
-    let is_recording_new = Arc::new(AtomicBool::new(false));
-    println!("Random Random Random 2");
     HttpServer::new(move || {
         App::new()
             .app_data( 
                 web::Data::new(RwLock::new(AppState {
                     map: HashMap::new(),
                     conn: addr.clone(),
-                    is_recording: is_recording_new.clone()
+                    is_recording: Arc::new(AtomicBool::new(false))
             })).clone())
             .service(web::resource("/user/startRecording").route(web::post().to(repositories::user_repository::start_recording)))
             .service(web::resource("/user/stopRecording").route(web::post().to(repositories::user_repository::stop_recording)))
@@ -168,5 +166,4 @@ async fn main() -> std::io::Result<()> {
     .bind(("0.0.0.0", 8080))?
     .run()
     .await
-    println!("Random Random Random 3");
 }

--- a/rust-webserver/src/main.rs
+++ b/rust-webserver/src/main.rs
@@ -20,7 +20,7 @@ use libc::{kill, SIGTERM};
 use serde_json::Error;
 use nix::unistd::Pid;
 use nix::sys::signal::{self, Signal};
-use std::sync::Arc;
+use std::sync::{atomic::{AtomicBool, Ordering}, Arc, Mutex};
 
 impl RedisActor {
     pub async fn new(redis_url: String) -> Self {
@@ -150,13 +150,15 @@ async fn main() -> std::io::Result<()> {
     let redis_url: String = env::var("REDIS_URL_GSTREAMER_PIPELINE").unwrap_or("none".to_string());
     let actor = RedisActor::new(redis_url).await;
     let addr = actor.start();
+    let is_recording = Arc::new(AtomicBool::new(false));
+    
     HttpServer::new(move || {
         App::new()
             .app_data( 
                 web::Data::new(RwLock::new(AppState {
                     map: HashMap::new(),
                     conn: addr.clone(),
-                    is_recording: Arc::new(RwLock::new(false))
+                    is_recording: is_recording.clone()
             })).clone())
             .service(web::resource("/user/startRecording").route(web::post().to(repositories::user_repository::start_recording)))
             .service(web::resource("/user/stopRecording").route(web::post().to(repositories::user_repository::stop_recording)))

--- a/rust-webserver/src/main.rs
+++ b/rust-webserver/src/main.rs
@@ -150,6 +150,7 @@ async fn main() -> std::io::Result<()> {
     let redis_url: String = env::var("REDIS_URL_GSTREAMER_PIPELINE").unwrap_or("none".to_string());
     let actor = RedisActor::new(redis_url).await;
     let addr = actor.start();
+    let is_recording = Arc::new(AtomicBool::new(false));
     println!("Random Random Random 1");
     HttpServer::new(move || {
         App::new()
@@ -157,7 +158,7 @@ async fn main() -> std::io::Result<()> {
                 web::Data::new(RwLock::new(AppState {
                     map: HashMap::new(),
                     conn: addr.clone(),
-                    is_recording: Arc::new(AtomicBool::new(false))
+                    is_recording: is_recording.clone()
             })).clone())
             .service(web::resource("/user/startRecording").route(web::post().to(repositories::user_repository::start_recording)))
             .service(web::resource("/user/stopRecording").route(web::post().to(repositories::user_repository::stop_recording)))

--- a/rust-webserver/src/repositories/user_repository/routes.rs
+++ b/rust-webserver/src/repositories/user_repository/routes.rs
@@ -213,13 +213,16 @@ pub async fn start_recording(
 
     println!("Random Random Random3");
     let mut state = app_state.write().unwrap();
-
+    println!("Random Random Random4");
     if state.is_recording.load(Ordering::SeqCst){
+        println!("Random Random Random5");
         return HttpResponse::NotFound().finish();
     }else {
+        println!("Random Random Random6");
         state.is_recording.store(true, Ordering::SeqCst);
     }
 
+    println!("Random Random Random7");
     let mut app: String =  Alphanumeric.sample_string(&mut rand::thread_rng(), 16).to_lowercase();
     let stream: String =  Alphanumeric.sample_string(&mut rand::thread_rng(), 16).to_lowercase();
     let mut redis_actor = &app_state.read().unwrap().conn;

--- a/rust-webserver/src/repositories/user_repository/routes.rs
+++ b/rust-webserver/src/repositories/user_repository/routes.rs
@@ -211,6 +211,7 @@ pub async fn start_recording(
         _ => false,
     };
 
+    println!("Random Random Random3");
     let mut state = app_state.write().unwrap();
 
     if state.is_recording.load(Ordering::SeqCst){

--- a/rust-webserver/src/repositories/user_repository/routes.rs
+++ b/rust-webserver/src/repositories/user_repository/routes.rs
@@ -76,6 +76,7 @@ pub struct AppState {
     pub is_recording: Arc<AtomicBool>,
 }
 
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct User {
     pub id: String
@@ -211,15 +212,17 @@ pub async fn start_recording(
         _ => false,
     };
 
-    println!("Random Random Random3");
-    let mut state = app_state.write().unwrap();
-    println!("Random Random Random4");
-    if state.is_recording.load(Ordering::SeqCst){
-        println!("Random Random Random5");
-        return HttpResponse::NotFound().finish();
-    }else {
-        println!("Random Random Random6");
-        state.is_recording.store(true, Ordering::SeqCst);
+    {
+        println!("Random Random Random3");
+        let mut state = app_state.write().unwrap();
+        println!("Random Random Random4");
+        if state.is_recording.load(Ordering::SeqCst){
+            println!("Random Random Random5");
+            return HttpResponse::NotFound().finish();
+        }else {
+            println!("Random Random Random6");
+            state.is_recording.store(true, Ordering::SeqCst);
+        }
     }
 
     println!("Random Random Random7");

--- a/rust-webserver/src/repositories/user_repository/routes.rs
+++ b/rust-webserver/src/repositories/user_repository/routes.rs
@@ -214,7 +214,7 @@ pub async fn start_recording(
     let mut state = app_state.write().unwrap();
 
     if state.is_recording.load(Ordering::SeqCst){
-        HttpResponse::NotFound().body("Recording already started")
+        return HttpResponse::NotFound().finish();
     }else {
         state.is_recording.store(true, Ordering::SeqCst);
     }

--- a/rust-webserver/src/repositories/user_repository/routes.rs
+++ b/rust-webserver/src/repositories/user_repository/routes.rs
@@ -212,14 +212,16 @@ pub async fn start_recording(
     };
 
     {
+        println!("Here ye here ye");
         let mut state = app_state.write().unwrap();
         let mut is_recording = state.is_recording.write().unwrap();
         if *is_recording {
+            println!("Here to the wild one");
             return HttpResponse::NotFound().finish();
         }
         *is_recording = true;
     }
-    
+
     let mut app: String =  Alphanumeric.sample_string(&mut rand::thread_rng(), 16).to_lowercase();
     let stream: String =  Alphanumeric.sample_string(&mut rand::thread_rng(), 16).to_lowercase();
     let mut redis_actor = &app_state.read().unwrap().conn;


### PR DESCRIPTION
Bug: Transcoder's API endpoint should only process one startRecording request. But service sometimes forwards both the requests to the same gstreamer pod since it was not marked busy before the second request. 

Fix: Use RWLock to lock a is_recording flag, which let's the endpoint return conflict when a second request comes to a pod. 
