### PR TITLE
Fix: Divisible by Two Error

### DIFF
--- a/rust-webserver/src/repositories/user_repository/routes.rs
+++ b/rust-webserver/src/repositories/user_repository/routes.rs
@@ -445,11 +445,12 @@ pub async fn start_recording(
         _ => format!("{} \
                     {} \
                     compositor name=video background=black \
-                    ! videoscale ! video/x-raw \
+                    ! videoscale \
+                    ! video/x-raw, width={}, height={}\
                     ! x264enc {} \
                     ! video/x-h264,profile={} \
                     ! flvmux streamable=true name=mux \
-                    ! rtmpsink location={}'", shared_pipeline, ingest_source, if is_low_latency { "speed-preset=ultrafast tune=zerolatency" } else { "" }, if video_width == 360 { "main" } else { "high" }, location), // Conditional x264enc parameters and profile
+                    ! rtmpsink location={}'", shared_pipeline, ingest_source, video_width, video_height,if is_low_latency { "speed-preset=ultrafast tune=zerolatency" } else { "" }, if video_width == 360 { "main" } else { "high" }, location), // Conditional x264enc parameters and profile
     };
 
     println!("gstreamer-pipeline: {}", gstreamer_pipeline);

--- a/rust-webserver/src/repositories/user_repository/routes.rs
+++ b/rust-webserver/src/repositories/user_repository/routes.rs
@@ -446,7 +446,7 @@ pub async fn start_recording(
                     {} \
                     compositor name=video background=black \
                     ! videoscale \
-                    ! video/x-raw,width=\\(int\\)[320,640],height=\\(int\\)[240,480] \
+                    ! video/x-raw,width=[320,640],height=[240,480] \
                     ! x264enc {} \
                     ! video/x-h264,profile={} \
                     ! flvmux streamable=true name=mux \

--- a/rust-webserver/src/repositories/user_repository/routes.rs
+++ b/rust-webserver/src/repositories/user_repository/routes.rs
@@ -450,7 +450,7 @@ pub async fn start_recording(
                     ! x264enc {} \
                     ! video/x-h264,profile={} \
                     ! flvmux streamable=true name=mux \
-                    ! rtmpsink location={}'", shared_pipeline, ingest_source, video_width, video_height,if is_low_latency { "speed-preset=ultrafast tune=zerolatency" } else { "" }, if video_width == 360 { "main" } else { "high" }, location), // Conditional x264enc parameters and profile
+                    ! rtmpsink location={}'", shared_pipeline, ingest_source, video_width*2, video_height*2,if is_low_latency { "speed-preset=ultrafast tune=zerolatency" } else { "" }, if video_width == 360 { "main" } else { "high" }, location), // Conditional x264enc parameters and profile
     };
 
     println!("gstreamer-pipeline: {}", gstreamer_pipeline);

--- a/rust-webserver/src/repositories/user_repository/routes.rs
+++ b/rust-webserver/src/repositories/user_repository/routes.rs
@@ -446,11 +446,11 @@ pub async fn start_recording(
                     {} \
                     compositor name=video background=black \
                     ! videoscale \
-                    ! video/x-raw,width=[320,640],height=[240,480] \
+                    ! video/x-raw,width=[{},{}],height=[{},{}] \
                     ! x264enc {} \
                     ! video/x-h264,profile={} \
                     ! flvmux streamable=true name=mux \
-                    ! rtmpsink location={}'", shared_pipeline, ingest_source,if is_low_latency { "speed-preset=ultrafast tune=zerolatency" } else { "" }, if video_width == 360 { "main" } else { "high" }, location), // Conditional x264enc parameters and profile
+                    ! rtmpsink location={}'", shared_pipeline, ingest_source, video_width, video_width*2, video_height, video_height*2,if is_low_latency { "speed-preset=ultrafast tune=zerolatency" } else { "" }, if video_width == 360 { "main" } else { "high" }, location), // Conditional x264enc parameters and profile
     };
 
     println!("gstreamer-pipeline: {}", gstreamer_pipeline);

--- a/rust-webserver/src/repositories/user_repository/routes.rs
+++ b/rust-webserver/src/repositories/user_repository/routes.rs
@@ -450,7 +450,7 @@ pub async fn start_recording(
                     ! x264enc {} \
                     ! video/x-h264,profile={} \
                     ! flvmux streamable=true name=mux \
-                    ! rtmpsink location={}'", shared_pipeline, ingest_source, video_width*2, video_height*2,if is_low_latency { "speed-preset=ultrafast tune=zerolatency" } else { "" }, if video_width == 360 { "main" } else { "high" }, location), // Conditional x264enc parameters and profile
+                    ! rtmpsink location={}'", shared_pipeline, ingest_source,if is_low_latency { "speed-preset=ultrafast tune=zerolatency" } else { "" }, if video_width == 360 { "main" } else { "high" }, location), // Conditional x264enc parameters and profile
     };
 
     println!("gstreamer-pipeline: {}", gstreamer_pipeline);

--- a/rust-webserver/src/repositories/user_repository/routes.rs
+++ b/rust-webserver/src/repositories/user_repository/routes.rs
@@ -446,7 +446,7 @@ pub async fn start_recording(
                     {} \
                     compositor name=video background=black \
                     ! videoscale \
-                    ! video/x-raw, width={}, height={}\
+                    ! video/x-raw,width=\(int\)[320,640],height=\(int\)[240,480] \
                     ! x264enc {} \
                     ! video/x-h264,profile={} \
                     ! flvmux streamable=true name=mux \

--- a/rust-webserver/src/repositories/user_repository/routes.rs
+++ b/rust-webserver/src/repositories/user_repository/routes.rs
@@ -446,7 +446,7 @@ pub async fn start_recording(
                     {} \
                     compositor name=video background=black \
                     ! videoscale \
-                    ! video/x-raw,width=\(int\)[320,640],height=\(int\)[240,480] \
+                    ! video/x-raw,width=\\(int\\)[320,640],height=\\(int\\)[240,480] \
                     ! x264enc {} \
                     ! video/x-h264,profile={} \
                     ! flvmux streamable=true name=mux \


### PR DESCRIPTION
Bug: Sometimes when a live streaming call is started, a width not divisible by two errors occurs, which is causing stability issues.

Fix: To make sure the widths are not 1 at times, we provide a range of width and height, to begin with. This makes sure that even if the first frame is missed and its height is 1, the video scale scales it up to the minimum value in the range. 